### PR TITLE
Versão inicial do fork do pacto

### DIFF
--- a/lib/pacto/formats/legacy/contract_builder.rb
+++ b/lib/pacto/formats/legacy/contract_builder.rb
@@ -71,11 +71,21 @@ module Pacto
                             headers: @filters.filter_request_headers(request, response),
                             http_method: request.method,
                             params: request.uri.query_values,
-                            path: hint.nil? ? request.uri.path : hint.path
+                            path: hint.nil? ? parse_path(request) : hint.path
                           )
           @data[:request] = request
           self
         end
+
+        def parse_path(request)
+          return request.uri.path unless get_request_with_query? request
+          request.uri.path + "?" + request.uri.query
+        end
+
+        def get_request_with_query?(request)
+          request.method.to_s == "get" && request.uri.query
+        end
+
 
         def generate_response(request, response)
           response = clean(

--- a/lib/pacto/formats/legacy/generator/filters.rb
+++ b/lib/pacto/formats/legacy/generator/filters.rb
@@ -16,6 +16,7 @@ module Pacto
           %w(
             Date
             Last-Modified
+            Etag
             ETag
           )
 

--- a/lib/pacto/formats/legacy/generator/filters.rb
+++ b/lib/pacto/formats/legacy/generator/filters.rb
@@ -19,7 +19,12 @@ module Pacto
             ETag
           )
 
-          HEADERS_TO_FILTER = CONNECTION_CONTROL_HEADERS + FRESHNESS_HEADERS
+          IMAGE_HEADERS =
+          %w(
+            Location
+          )
+
+          HEADERS_TO_FILTER = CONNECTION_CONTROL_HEADERS + FRESHNESS_HEADERS + IMAGE_HEADERS
 
           def filter_request_headers(request, response)
             # FIXME: Do we need to handle all these cases in real situations, or just because of stubbing?

--- a/pacto.gemspec
+++ b/pacto.gemspec
@@ -21,7 +21,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(/^(test|spec|features)\//)
   gem.require_paths = ['lib']
 
-  gem.add_dependency 'webmock', '~> 1.18'
+  gem.add_dependency 'webmock', '~> 2.1.0'
   gem.add_dependency 'swagger-core', '~> 0.2', '>= 0.2.1'
   gem.add_dependency 'middleware', '~> 0.1'
   gem.add_dependency 'multi_json', '~> 1.8'


### PR DESCRIPTION
- [x] Utilizar a versão WebMock 2.1.0
- [x] Tratamento para contratos com o método GET
- [x] Adição de filtro para os headers Etag e Location